### PR TITLE
test: add unit tests for cipherState

### DIFF
--- a/common/src/noise-spa/CipherState.ts
+++ b/common/src/noise-spa/CipherState.ts
@@ -49,17 +49,17 @@ export class CipherState {
   decrypt(ad: Buffer, ciphertext: Buffer): Buffer {
     const nonce = Buffer.alloc(12);
     nonce.writeBigUInt64LE(BigInt(this.nonce), 4);
-    const cipher = CipherState.createDecipher(this.key, nonce);
+    const decipher = CipherState.createDecipher(this.key, nonce);
 
     const realCiphertext = ciphertext.subarray(0, -TAG_SIZE);
     const tag = ciphertext.subarray(-TAG_SIZE);
 
-    cipher.setAuthTag(tag);
-    cipher.setAAD(ad, { plaintextLength: realCiphertext.byteLength });
+    decipher.setAuthTag(tag);
+    decipher.setAAD(ad, { plaintextLength: realCiphertext.byteLength });
 
     const plaintext = Buffer.concat([
-      cipher.update(realCiphertext),
-      cipher.final(),
+      decipher.update(realCiphertext),
+      decipher.final(),
     ]);
 
     this.nonce++;

--- a/common/src/noise-spa/exceptions/InvalidKeySizeError.ts
+++ b/common/src/noise-spa/exceptions/InvalidKeySizeError.ts
@@ -1,0 +1,6 @@
+export class InvalidKeySizeError extends Error {
+  constructor(expected: number, got: number) {
+    super(`Key should be exactly ${expected} bytes, got ${got}`);
+    this.name = "InvalidKeySizeError";
+  }
+}

--- a/common/tst/CipherState.test.ts
+++ b/common/tst/CipherState.test.ts
@@ -1,0 +1,84 @@
+import { CipherState } from "../src/noise-spa/CipherState";
+import { InvalidKeySizeError } from "../src/noise-spa/exceptions/InvalidKeySizeError";
+import { EMPTY_KEY, KEY_SIZE, TAG_SIZE } from "../src/noise-spa/constants";
+import { randomBytes } from "crypto";
+import { x25519 } from "@noble/curves/ed25519";
+
+describe("CipherState", () => {
+  // Example test values
+  const TEST_KEY = Buffer.alloc(KEY_SIZE, 0xdeadbeefcafe);
+  const TEST_AD = Buffer.from("associated data");
+  const TEST_PLAINTEXT = Buffer.from("hello world");
+  const TEST_EMPTY_KEY = Buffer.alloc(KEY_SIZE, 0x00);
+
+  it("constructs with a valid key", () => {
+    expect(() => new CipherState(TEST_KEY)).not.toThrow();
+  });
+
+  it("throws InvalidKeySizeError with an invalid key", () => {
+    for (let keySize = 0; keySize < KEY_SIZE; ++keySize) {
+      const invalidKey = randomBytes(keySize);
+      expect(() => new CipherState(invalidKey)).toThrow(
+        new InvalidKeySizeError(KEY_SIZE, keySize),
+      );
+    }
+  });
+
+  it("hasKey() returns false for empty key", () => {
+    const cs = new CipherState(TEST_EMPTY_KEY);
+    expect(cs.hasKey()).toStrictEqual(false);
+  });
+
+  it("hasKey() returns true for non-empty key", () => {
+    const cs = new CipherState(TEST_KEY);
+    expect(cs.hasKey()).toStrictEqual(true);
+  });
+
+  it("encrypts and decrypts correctly with AAD", () => {
+    const cs = new CipherState(TEST_KEY);
+
+    const ciphertext = cs.encrypt(TEST_AD, TEST_PLAINTEXT);
+    expect(ciphertext.byteLength).toStrictEqual(
+      TEST_PLAINTEXT.byteLength + TAG_SIZE,
+    );
+
+    // Decrypt with a new CipherState (to reset nonce)
+    const cs2 = new CipherState(TEST_KEY);
+    const decrypted = cs2.decrypt(TEST_AD, ciphertext);
+    expect(decrypted).toStrictEqual(TEST_PLAINTEXT);
+  });
+
+  it("throws if state is wrong", () => {
+    const cs = new CipherState(TEST_KEY);
+    cs.encrypt(TEST_AD, TEST_PLAINTEXT);
+
+    // Use the same state so the nonce is wrong
+    expect(() =>
+      cs.decrypt(TEST_AD, cs.encrypt(TEST_AD, TEST_PLAINTEXT)),
+    ).toThrow();
+  });
+
+  it("throws if ciphertext is tampered", () => {
+    const cs = new CipherState(TEST_KEY);
+    const ciphertext = cs.encrypt(TEST_AD, TEST_PLAINTEXT);
+
+    // Tamper with ciphertext
+    const tampered = Buffer.from(ciphertext);
+    tampered[0] ^= 0xff;
+
+    const cs2 = new CipherState(TEST_KEY);
+    expect(() => cs2.decrypt(TEST_AD, tampered)).toThrow();
+  });
+
+  it("throws if tag is tampered", () => {
+    const cs = new CipherState(TEST_KEY);
+    const ciphertext = cs.encrypt(TEST_AD, TEST_PLAINTEXT);
+
+    // Tamper with tag (last TAG_SIZE bytes)
+    const tampered = Buffer.from(ciphertext);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    const cs2 = new CipherState(TEST_KEY);
+    expect(() => cs2.decrypt(TEST_AD, tampered)).toThrow();
+  });
+});


### PR DESCRIPTION
CipherState.ts \: 
* Add an assert in CipherState key byteLength
* Move createCipher and createDecipher to private methods

Tests \:
* unit test haskey
* unit test the constructor assert
* unit test encrypt & decrypt, with tampering of ciphertext, tag, and state