### PR TITLE
Test auth and integrity for message A

### DIFF
--- a/common/src/server.ts
+++ b/common/src/server.ts
@@ -50,7 +50,9 @@ export class Server extends EventEmitter<ServerEvents> {
       send: (msg: string) => {
         const spa = hs.writeMessageB(Buffer.from(msg));
 
-        client.send(spa.pack(), rinfo.port, rinfo.address);
+        client.send(spa.pack(), rinfo.port, rinfo.address, (err) => {
+          client.close();
+        });
       },
     });
   }

--- a/common/tst/Echo.test.ts
+++ b/common/tst/Echo.test.ts
@@ -1,0 +1,85 @@
+import {
+  Key,
+  KeyPair,
+  Client,
+  Server,
+  HandshakeInitiatorOptions,
+} from "../src";
+
+describe("UDP Echo Server", () => {
+  // UDP Parameters
+  const HOST = "127.0.0.1";
+  const PORT = 41234;
+
+  let server: Server;
+  let client: Client;
+
+  // Server-specific parameters
+  const s = KeyPair.fromPrivate(
+    Buffer.from(
+      "126e5c21772c68e1398cc48c0880f349fb410cdcca953c89a84cdba17fd9df72",
+      "hex",
+    ),
+  );
+
+  const clients: Record<string, Key> = {
+    e51eaac8fe8aac9d95b3a7d215b330fb1b09bafc54625c22e76656190d98b246:
+      Buffer.from(
+        "9775b0f777581be4c9922c7b001ec9ce01f044216b4a30d63b5a5b411300c68b",
+        "hex",
+      ),
+  };
+  const getPSKbyID = (id: Key): Key | null =>
+    clients[id.toString("hex")] ?? null;
+
+  // Client-specific parameters
+  const hsOptions: HandshakeInitiatorOptions = {
+    s: KeyPair.fromPrivate(
+      Buffer.from(
+        "5db979a88bc2a2203df03acf4dd946b89fdb9293242a557778c69b7f29382e76",
+        "hex",
+      ),
+    ),
+    rs: Buffer.from(
+      "d922a623f61caadbd44f716dcd9f59423c791f50e016eb9cfed28509b334f80b",
+      "hex",
+    ),
+    psk: Buffer.from(
+      "9775b0f777581be4c9922c7b001ec9ce01f044216b4a30d63b5a5b411300c68b",
+      "hex",
+    ),
+  };
+
+  beforeAll((done) => {
+    server = new Server(HOST, PORT, s, getPSKbyID);
+    server.bind();
+
+    server.on("listening", () => {
+      server.on("message", (msg, { send }) => {
+        send(msg.toString());
+      });
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.once("close", done);
+    server["socket"].close();
+  });
+
+  it("should echo back the same message", async () => {
+    client = new Client(HOST, PORT, hsOptions);
+    const payload = Buffer.from("hello, world");
+    const response = await client.send(payload);
+    expect(response.toString()).toBe("hello, world");
+  });
+
+  it("should handle multiple messages", async () => {
+    client = new Client(HOST, PORT, hsOptions);
+    for (const text of ["foo", "bar", "baz"]) {
+      const buf = Buffer.from(text);
+      const res = await client.send(buf);
+      expect(res.toString()).toBe(text);
+    }
+  });
+});

--- a/common/tst/KeyPair.test.ts
+++ b/common/tst/KeyPair.test.ts
@@ -1,4 +1,3 @@
-import { randomInt } from "crypto";
 import { KeyPair } from "../src";
 import { KEY_SIZE } from "../src/noise-spa/constants";
 
@@ -7,12 +6,4 @@ test("KeyPair.generate should generate KEY_SIZE long keys by default", () => {
 
   expect(keyPair.getPublic().length).toBe(KEY_SIZE);
   expect(keyPair.getPrivate().length).toBe(KEY_SIZE);
-});
-
-test("KeyPair.generate should generate keySize long keys", () => {
-  const keySize = randomInt(128);
-  const keyPair = KeyPair.generate(keySize);
-
-  expect(keyPair.getPublic().length).toBe(keySize);
-  expect(keyPair.getPrivate().length).toBe(keySize);
 });

--- a/common/tst/MessageA.test.ts
+++ b/common/tst/MessageA.test.ts
@@ -1,0 +1,125 @@
+import {
+  HandshakeInitiator,
+  HandshakeInitiatorOptions,
+} from "../src/noise-spa/HandshakeInitiator";
+import {
+  HandshakeResponder,
+  HandshakeResponderOptions,
+} from "../src/noise-spa/HandshakeResponder";
+import { KeyPair, Key } from "../src";
+import { randomBytes } from "crypto";
+import { KEY_SIZE } from "../src/noise-spa/constants";
+
+describe("IKpsk1 Message A", () => {
+  let aliceHS: HandshakeInitiator;
+  let bobHS: HandshakeResponder;
+
+  // Handshake Initatior
+  const hsInitiatorOptions: HandshakeInitiatorOptions = {
+    s: KeyPair.fromPrivate(
+      Buffer.from(
+        "5db979a88bc2a2203df03acf4dd946b89fdb9293242a557778c69b7f29382e76",
+        "hex",
+      ),
+    ),
+    rs: Buffer.from(
+      "d922a623f61caadbd44f716dcd9f59423c791f50e016eb9cfed28509b334f80b",
+      "hex",
+    ),
+    psk: Buffer.from(
+      "9775b0f777581be4c9922c7b001ec9ce01f044216b4a30d63b5a5b411300c68b",
+      "hex",
+    ),
+  };
+
+  // Handshake Responder
+  const hsResponderOptions: HandshakeResponderOptions = {
+    s: KeyPair.fromPrivate(
+      Buffer.from(
+        "126e5c21772c68e1398cc48c0880f349fb410cdcca953c89a84cdba17fd9df72",
+        "hex",
+      ),
+    ),
+  };
+
+  const clients: Record<string, Key> = {
+    e51eaac8fe8aac9d95b3a7d215b330fb1b09bafc54625c22e76656190d98b246:
+      Buffer.from(
+        "9775b0f777581be4c9922c7b001ec9ce01f044216b4a30d63b5a5b411300c68b",
+        "hex",
+      ),
+  };
+  const getPSKbyID = (id: Key): Key | null =>
+    clients[id.toString("hex")] ?? null;
+
+  beforeEach(() => {
+    aliceHS = new HandshakeInitiator(hsInitiatorOptions);
+    bobHS = new HandshakeResponder(hsResponderOptions);
+  });
+
+  test("Mutual authentification and message integrity", () => {
+    const payload = Buffer.from("hello");
+    const msg = aliceHS.writeMessageA(payload).pack();
+    const { timestamp, plaintext } = bobHS.readMessageA(msg, getPSKbyID);
+
+    // expect(ok).toBe(true);
+    expect(plaintext).toEqual(payload);
+  });
+
+  test("Sender authentication and KCI resistance", () => {
+    // simulate compromise of Alice's static only (no PSK leak)
+    aliceHS = new HandshakeInitiator({
+      ...hsInitiatorOptions,
+      s: KeyPair.fromPrivate(randomBytes(KEY_SIZE)),
+    });
+
+    const msg = aliceHS.writeMessageA(Buffer.from("x")).pack();
+
+    // should NOT accept a message if only Alice's static key was compromised
+    expect(() => {
+      bobHS.readMessageA(msg, getPSKbyID);
+    }).toThrow(Error);
+  });
+
+  test("Message secrecy (without keys)", () => {
+    const payload = Buffer.from("hello");
+    const msg = aliceHS.writeMessageA(payload).pack();
+
+    // No keys
+    bobHS = new HandshakeResponder({
+      s: KeyPair.fromPrivate(randomBytes(KEY_SIZE)),
+    });
+    const getFakePSK = (rs: Key): Buffer => randomBytes(KEY_SIZE);
+
+    expect(() => {
+      bobHS.readMessageA(msg, getFakePSK);
+    }).toThrow();
+  });
+
+  test("Message secrecy (PSK key leakage)", () => {
+    const payload = Buffer.from("hello");
+    const msg = aliceHS.writeMessageA(payload).pack();
+
+    // PSK Key leakage
+    bobHS = new HandshakeResponder({
+      s: KeyPair.fromPrivate(randomBytes(KEY_SIZE)),
+    });
+
+    expect(() => {
+      bobHS.readMessageA(msg, getPSKbyID);
+    }).toThrow();
+  });
+
+  test("Message secrecy (Static keys leakage)", () => {
+    const payload = Buffer.from("hello");
+    const msg = aliceHS.writeMessageA(payload).pack();
+
+    // Bob's static keys leakage
+    // bobHS = new HandshakeResponder(hsResponderOptions);
+    const getFakePSK = (rs: Key): Buffer => randomBytes(KEY_SIZE);
+
+    expect(() => {
+      bobHS.readMessageA(msg, getFakePSK);
+    }).toThrow();
+  });
+});

--- a/common/tst/hello.test.ts
+++ b/common/tst/hello.test.ts
@@ -1,3 +1,0 @@
-test("Helorlwrold test", () => {
-  expect(1 + 43).toBe(44);
-});


### PR DESCRIPTION
- Add new tests to assess the integrity and authenticity of message A (Alice's compromised static key, PSK key leakage, and Bob's static key leakage).
- Close the connection between the client and the server after the server's response.
- Remove the 2nd test in KeyPair test.